### PR TITLE
Change overall score rounding and update associated unit tests

### DIFF
--- a/ela_rag_docker/database.py
+++ b/ela_rag_docker/database.py
@@ -392,9 +392,9 @@ def calculate_overall_score(results_data: list) -> float:
 
     # IELTS-specific rounding
     if average % 1 == 0.25:
-        overall_score = round(average + 0.25, 1)
+        overall_score = round(average - 0.25, 1)
     elif average % 1 == 0.75:
-        overall_score = round(average + 0.25, 1)
+        overall_score = round(average - 0.25, 1)
     else:
         overall_score = round(average * 2) / 2
 

--- a/ela_rag_docker/test_scripts/test_database.py
+++ b/ela_rag_docker/test_scripts/test_database.py
@@ -192,7 +192,7 @@ def test_get_or_create_user_existing():
 # TEST calculate_overall_score
 # ------------------------------------------------------------------------------------------
 
-def test_rounding_up_6_25():
+def test_rounding_down_6_25():
 
     results = [
         {"competency_name": "Task Response", "score": 6.0, "feedback_summary": "", "submission_id": 1},
@@ -201,9 +201,9 @@ def test_rounding_up_6_25():
         {"competency_name": "Grammatical Range and Accuracy", "score": 6.5, "feedback_summary": "", "submission_id": 1},
     ]
 
-    assert calculate_overall_score(results) == 6.5
+    assert calculate_overall_score(results) == 6.0
 
-def test_rounding_up_6_75():
+def test_rounding_down_6_75():
 
     results = [
         {"competency_name": "Task Response", "score": 7.0, "feedback_summary": "", "submission_id": 1},
@@ -212,7 +212,7 @@ def test_rounding_up_6_75():
         {"competency_name": "Grammatical Range and Accuracy", "score": 6.5, "feedback_summary": "", "submission_id": 1},
     ]
 
-    assert calculate_overall_score(results) == 7.0
+    assert calculate_overall_score(results) == 6.5
 
 def test_no_rounding_half_band():
 


### PR DESCRIPTION
Changed the calculate overall score function to round down when the average score ends in .25 or .75 (previously was round up). Also changed the associated unit tests, ran them and confirmed it's working as intended. 